### PR TITLE
Event exclude profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=github.com
 NAMESPACE=uptycslabs
 NAME=uptycs
 BINARY=terraform-provider-${NAME}
-VERSION=0.0.3
+VERSION=0.0.4
 OS_ARCH=darwin_amd64
 
 default: install

--- a/examples/alert_rule.tf
+++ b/examples/alert_rule.tf
@@ -8,10 +8,10 @@ terraform {
 }
 
 provider "uptycs" {
-  host = "https://test.uptycs.io"
+  host        = "https://test.uptycs.io"
   customer_id = "11111111-1111-1111-1111-11111111111"
-  api_key = "2222222222222222222222"
-  api_secret = "234444444444433333333333222222221111111"
+  api_key     = "2222222222222222222222"
+  api_secret  = "234444444444433333333333222222221111111"
 }
 
 resource "uptycs_alert_rule" "test" {

--- a/examples/destination.tf
+++ b/examples/destination.tf
@@ -8,10 +8,10 @@ terraform {
 }
 
 provider "uptycs" {
-  host = "https://test.uptycs.io"
+  host        = "https://test.uptycs.io"
   customer_id = "11111111-1111-1111-1111-11111111111"
-  api_key = "2222222222222222222222"
-  api_secret = "234444444444433333333333222222221111111"
+  api_key     = "2222222222222222222222"
+  api_secret  = "234444444444433333333333222222221111111"
 }
 
 data "uptycs_destination" "foo" {
@@ -19,9 +19,9 @@ data "uptycs_destination" "foo" {
 }
 
 resource "uptycs_destination" "test" {
-  name = "marc test"
+  name    = "marc test"
   address = "marcus.young@foo.com"
-  type = "email"
+  type    = "email"
 }
 
 output "foo" {

--- a/examples/event_exclude_profiles.tf
+++ b/examples/event_exclude_profiles.tf
@@ -1,0 +1,58 @@
+terraform {
+  required_providers {
+    uptycs = {
+      source  = "uptycslabs/uptycs"
+      version = "0.0.4"
+    }
+  }
+}
+
+provider "uptycs" {
+  host        = "https://test.uptycs.io"
+  customer_id = "11111111-1111-1111-1111-11111111111"
+  api_key     = "2222222222222222222222"
+  api_secret  = "234444444444433333333333222222221111111"
+}
+
+data "uptycs_event_exclude_profile" "sample" {
+  id = "2a86d4ad-3aa3-42f1-8430-6da238c82b11"
+}
+
+resource "uptycs_event_exclude_profile" "sample" {
+  name = "marc test"
+  description = "a test"
+  priority = 9999
+  platform = "all"
+  metadata = <<EOT
+{
+  "dns_lookup_events": {},
+  "user_events": {},
+  "socket_events": {},
+  "process_events": {
+    "path": [
+      "^/Library/Developer/Xcode$"
+    ]
+  },
+  "registry_events": {},
+  "process_file_events": {
+    "path": [
+      "^/Library/Developer/Xcode$",
+      "^/Library/Application Support/JAMF$"
+    ],
+    "executable": [
+      "^.*osqueryd\\.exe$|^.*collectguestlogs\\.exe$|^.*MsMpEng\\.exe$"
+    ]
+  }
+}
+EOT
+}
+
+output "source_name" {
+  value = data.uptycs_event_exclude_profile.sample.name
+}
+output "source_priority" {
+  value = data.uptycs_event_exclude_profile.sample.priority
+}
+output "source_metadata" {
+  value = data.uptycs_event_exclude_profile.sample.metadata
+}

--- a/examples/event_rule.tf
+++ b/examples/event_rule.tf
@@ -8,10 +8,10 @@ terraform {
 }
 
 provider "uptycs" {
-  host = "https://test.uptycs.io"
+  host        = "https://test.uptycs.io"
   customer_id = "11111111-1111-1111-1111-11111111111"
-  api_key = "2222222222222222222222"
-  api_secret = "234444444444433333333333222222221111111"
+  api_key     = "2222222222222222222222"
+  api_secret  = "234444444444433333333333222222221111111"
 }
 
 resource "uptycs_event_rule" "Access_Key_Created" {
@@ -21,25 +21,25 @@ resource "uptycs_event_rule" "Access_Key_Created" {
   grouping    = "ATTACK"
   grouping_l2 = "Privilege Escalation"
   grouping_l3 = "T1078"
-  code = "AWS_THREAT_PRIV_ESC_1"
-  type = "builder"
-  rule = "builder"
+  code        = "AWS_THREAT_PRIV_ESC_1"
+  type        = "builder"
+  rule        = "builder"
   event_tags = [
     "ATTACK",
     "AWS",
   ]
   builder_config = {
-    table_name = "upt_cloud_trail_events"
-    added = true
+    table_name     = "upt_cloud_trail_events"
+    added          = true
     matches_filter = true
-    severity = "low"
-    key = "upt_tenant_id"
-    value_field = "user_identity_user_name"
+    severity       = "low"
+    key            = "upt_tenant_id"
+    value_field    = "user_identity_user_name"
     auto_alert_config = {
-      raise_alert = true
+      raise_alert   = true
       disable_alert = false
     }
-    filters =<<EOT
+    filters = <<EOT
 {
   "and": [
     {
@@ -88,9 +88,9 @@ resource "uptycs_event_rule" "a_different_rule" {
   grouping    = "ATTACK"
   grouping_l2 = "Privilege Escalation"
   grouping_l3 = "T1078"
-  code = "AWS_THREAT_PRIV_ESC_1"
-  type = "builder"
-  rule = "builder"
+  code        = "AWS_THREAT_PRIV_ESC_1"
+  type        = "builder"
+  rule        = "builder"
   event_tags = [
     "ATTACK",
     "AWS",

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v0.8.0
 	github.com/hashicorp/terraform-plugin-go v0.9.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
-	github.com/uptycslabs/uptycs-client-go v0.0.13
+	github.com/uptycslabs/uptycs-client-go v0.0.15
 	gopkg.in/yaml.v3 v3.0.1 // indirect; CVE-2022-28948
+	github.com/Masterminds/goutils v1.1.1 // indirect; https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMMASTERMINDSGOUTILS-1296313
 )
 
 require (
-	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.0 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v0.8.0
 	github.com/hashicorp/terraform-plugin-go v0.9.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
-	github.com/uptycslabs/uptycs-client-go v0.0.15
+	github.com/uptycslabs/uptycs-client-go v0.0.17
 	gopkg.in/yaml.v3 v3.0.1 // indirect; CVE-2022-28948
 	github.com/Masterminds/goutils v1.1.1 // indirect; https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMMASTERMINDSGOUTILS-1296313
 )

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,10 @@ github.com/uptycslabs/uptycs-client-go v0.0.14 h1:FbSusdODGBjUYUOgrFoUFMFyNOsdXO
 github.com/uptycslabs/uptycs-client-go v0.0.14/go.mod h1:xkiTJfPiiDp6kc1hbgOgTQcsJuSt0y4yNpxkSe358tc=
 github.com/uptycslabs/uptycs-client-go v0.0.15 h1:OhT8U8zpZEPCOhS62biYz1FICmrirMvvP0QBCQKE7dE=
 github.com/uptycslabs/uptycs-client-go v0.0.15/go.mod h1:xkiTJfPiiDp6kc1hbgOgTQcsJuSt0y4yNpxkSe358tc=
+github.com/uptycslabs/uptycs-client-go v0.0.16 h1:EXUYyNU1tWrjDIS1MpogNUdVq761Mz5ZQuaQujiEaNw=
+github.com/uptycslabs/uptycs-client-go v0.0.16/go.mod h1:xkiTJfPiiDp6kc1hbgOgTQcsJuSt0y4yNpxkSe358tc=
+github.com/uptycslabs/uptycs-client-go v0.0.17 h1:3Mmq2GpMiRqhhuVN5SPipBhSwh4hGH+5D3Sl6d4dVTQ=
+github.com/uptycslabs/uptycs-client-go v0.0.17/go.mod h1:xkiTJfPiiDp6kc1hbgOgTQcsJuSt0y4yNpxkSe358tc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.0 h1:P1ekkbuU73Ui/wS0nK1HOM37hh4xdfZo485UPf8rc+Y=
@@ -256,6 +258,10 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/uptycslabs/uptycs-client-go v0.0.13 h1:z0PTh5ssjOqg3yZYIXS3opz1EGL2vqr9DFVa77elfQA=
 github.com/uptycslabs/uptycs-client-go v0.0.13/go.mod h1:xkiTJfPiiDp6kc1hbgOgTQcsJuSt0y4yNpxkSe358tc=
+github.com/uptycslabs/uptycs-client-go v0.0.14 h1:FbSusdODGBjUYUOgrFoUFMFyNOsdXOC97ZjWeV/C11A=
+github.com/uptycslabs/uptycs-client-go v0.0.14/go.mod h1:xkiTJfPiiDp6kc1hbgOgTQcsJuSt0y4yNpxkSe358tc=
+github.com/uptycslabs/uptycs-client-go v0.0.15 h1:OhT8U8zpZEPCOhS62biYz1FICmrirMvvP0QBCQKE7dE=
+github.com/uptycslabs/uptycs-client-go v0.0.15/go.mod h1:xkiTJfPiiDp6kc1hbgOgTQcsJuSt0y4yNpxkSe358tc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/uptycs/data_source_destination.go
+++ b/uptycs/data_source_destination.go
@@ -57,7 +57,6 @@ func (d dataSourceDestinationType) Read(ctx context.Context, req tfsdk.ReadDataS
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error reading order",
 			"Could not get destination with ID  "+destinationId+": "+err.Error(),
 		)
 		return

--- a/uptycs/data_source_destination.go
+++ b/uptycs/data_source_destination.go
@@ -57,6 +57,7 @@ func (d dataSourceDestinationType) Read(ctx context.Context, req tfsdk.ReadDataS
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
+			"Failed to read.",
 			"Could not get destination with ID  "+destinationId+": "+err.Error(),
 		)
 		return

--- a/uptycs/data_source_event_exclude_profile.go
+++ b/uptycs/data_source_event_exclude_profile.go
@@ -1,0 +1,96 @@
+package uptycs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/uptycslabs/uptycs-client-go/uptycs"
+)
+
+type dataSourceEventExcludeProfileType struct {
+	p provider
+}
+
+func (r dataSourceEventExcludeProfileType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"id": {
+				Type:     types.StringType,
+				Optional: true,
+			},
+			"name": {
+				Type:     types.StringType,
+				Optional: true,
+			},
+			"description": {
+				Type:     types.StringType,
+				Optional: true,
+			},
+			"priority": {
+				Type:     types.NumberType,
+				Optional: true,
+			},
+			"resource_type": {
+				Type:     types.StringType,
+				Optional: true,
+			},
+			"platform": {
+				Type:     types.StringType,
+				Optional: true,
+			},
+			"metadata": {
+				Optional: true,
+				Type:     types.StringType,
+			},
+		},
+	}, nil
+}
+
+func (d dataSourceEventExcludeProfileType) NewDataSource(_ context.Context, p tfsdk.Provider) (tfsdk.DataSource, diag.Diagnostics) {
+	return dataSourceEventExcludeProfileType{
+		p: *(p.(*provider)),
+	}, nil
+}
+
+func (d dataSourceEventExcludeProfileType) Read(ctx context.Context, req tfsdk.ReadDataSourceRequest, resp *tfsdk.ReadDataSourceResponse) {
+	var eventExcludeProfileId string
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, tftypes.NewAttributePath().WithAttributeName("id"), &eventExcludeProfileId)...)
+
+	eventExcludeProfileResp, err := d.p.client.GetEventExcludeProfile(uptycs.EventExcludeProfile{
+		ID: eventExcludeProfileId,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to read.",
+			"Could not get eventExcludeProfile with ID  "+eventExcludeProfileId+": "+err.Error(),
+		)
+		return
+	}
+
+	metadataJson, err := json.MarshalIndent(eventExcludeProfileResp.Metadata, "", "  ")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var result = EventExcludeProfile{
+		ID:           types.String{Value: eventExcludeProfileResp.ID},
+		Name:         types.String{Value: eventExcludeProfileResp.Name},
+		Description:  types.String{Value: eventExcludeProfileResp.Description},
+		Metadata:     types.String{Value: string([]byte(metadataJson)) + "\n"},
+		Priority:     eventExcludeProfileResp.Priority,
+		ResourceType: types.String{Value: eventExcludeProfileResp.ResourceType},
+		Platform:     types.String{Value: eventExcludeProfileResp.Platform},
+	}
+
+	diags := resp.State.Set(ctx, result)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+}

--- a/uptycs/models.go
+++ b/uptycs/models.go
@@ -65,3 +65,13 @@ type Destination struct {
 	Enabled types.Bool `tfsdk:"enabled"`
 	//Template TODO
 }
+
+type EventExcludeProfile struct {
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Description  types.String `tfsdk:"description"`
+	Priority     int          `tfsdk:"priority"`
+	Metadata     types.String `tfsdk:"metadata"`
+	ResourceType types.String `tfsdk:"resource_type"`
+	Platform     types.String `tfsdk:"platform"`
+}

--- a/uptycs/provider.go
+++ b/uptycs/provider.go
@@ -191,15 +191,17 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 // GetResources - Defines provider resources
 func (p *provider) GetResources(_ context.Context) (map[string]tfsdk.ResourceType, diag.Diagnostics) {
 	return map[string]tfsdk.ResourceType{
-		"uptycs_alert_rule":  resourceAlertRuleType{},
-		"uptycs_event_rule":  resourceEventRuleType{},
-		"uptycs_destination": resourceDestinationType{},
+		"uptycs_alert_rule":            resourceAlertRuleType{},
+		"uptycs_event_rule":            resourceEventRuleType{},
+		"uptycs_destination":           resourceDestinationType{},
+		"uptycs_event_exclude_profile": resourceEventExcludeProfileType{},
 	}, nil
 }
 
 // GetDataSources - Defines provider data sources
 func (p *provider) GetDataSources(_ context.Context) (map[string]tfsdk.DataSourceType, diag.Diagnostics) {
 	return map[string]tfsdk.DataSourceType{
-		"uptycs_destination": dataSourceDestinationType{},
+		"uptycs_destination":           dataSourceDestinationType{},
+		"uptycs_event_exclude_profile": dataSourceEventExcludeProfileType{},
 	}, nil
 }

--- a/uptycs/resource_alert_rule.go
+++ b/uptycs/resource_alert_rule.go
@@ -154,7 +154,6 @@ func (r resourceAlertRule) Read(ctx context.Context, req tfsdk.ReadResourceReque
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error reading order",
 			"Could not get alertRule with ID  "+alertRuleId+": "+err.Error(),
 		)
 		return
@@ -265,7 +264,6 @@ func (r resourceAlertRule) Delete(ctx context.Context, req tfsdk.DeleteResourceR
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error deleting order",
 			"Could not delete alertRule with ID  "+alertRuleID+": "+err.Error(),
 		)
 		return

--- a/uptycs/resource_alert_rule.go
+++ b/uptycs/resource_alert_rule.go
@@ -116,7 +116,7 @@ func (r resourceAlertRule) Create(ctx context.Context, req tfsdk.CreateResourceR
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error creating alertRule",
+			"Error creating",
 			"Could not create alertRule, unexpected error: "+err.Error(),
 		)
 		return
@@ -154,6 +154,7 @@ func (r resourceAlertRule) Read(ctx context.Context, req tfsdk.ReadResourceReque
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
+			"Error reading",
 			"Could not get alertRule with ID  "+alertRuleId+": "+err.Error(),
 		)
 		return
@@ -219,7 +220,7 @@ func (r resourceAlertRule) Update(ctx context.Context, req tfsdk.UpdateResourceR
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error creating alertRule",
+			"Error creating",
 			"Could not create alertRule, unexpected error: "+err.Error(),
 		)
 		return
@@ -264,6 +265,7 @@ func (r resourceAlertRule) Delete(ctx context.Context, req tfsdk.DeleteResourceR
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
+			"Error Deleting",
 			"Could not delete alertRule with ID  "+alertRuleID+": "+err.Error(),
 		)
 		return

--- a/uptycs/resource_destination.go
+++ b/uptycs/resource_destination.go
@@ -32,9 +32,9 @@ func (r resourceDestinationType) GetSchema(_ context.Context) (tfsdk.Schema, dia
 				Optional: true,
 			},
 			"enabled": {
-				Type:     types.BoolType,
-				Optional: true,
-				Computed: true,
+				Type:          types.BoolType,
+				Optional:      true,
+				Computed:      true,
 				PlanModifiers: tfsdk.AttributePlanModifiers{boolDefault(true)},
 			},
 		},
@@ -79,7 +79,7 @@ func (r resourceDestination) Create(ctx context.Context, req tfsdk.CreateResourc
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error creating destination",
+			"Error creating",
 			"Could not create destination, unexpected error: "+err.Error(),
 		)
 		return
@@ -109,6 +109,7 @@ func (r resourceDestination) Read(ctx context.Context, req tfsdk.ReadResourceReq
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
+			"Error reading",
 			"Could not get destination with ID  "+destinationId+": "+err.Error(),
 		)
 		return
@@ -158,7 +159,7 @@ func (r resourceDestination) Update(ctx context.Context, req tfsdk.UpdateResourc
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error creating destination",
+			"Error creating",
 			"Could not create destination, unexpected error: "+err.Error(),
 		)
 		return
@@ -195,6 +196,7 @@ func (r resourceDestination) Delete(ctx context.Context, req tfsdk.DeleteResourc
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
+			"Error deleting",
 			"Could not delete destination with ID  "+destinationID+": "+err.Error(),
 		)
 		return

--- a/uptycs/resource_destination.go
+++ b/uptycs/resource_destination.go
@@ -109,7 +109,6 @@ func (r resourceDestination) Read(ctx context.Context, req tfsdk.ReadResourceReq
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error reading order",
 			"Could not get destination with ID  "+destinationId+": "+err.Error(),
 		)
 		return
@@ -196,7 +195,6 @@ func (r resourceDestination) Delete(ctx context.Context, req tfsdk.DeleteResourc
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error deleting order",
 			"Could not delete destination with ID  "+destinationID+": "+err.Error(),
 		)
 		return

--- a/uptycs/resource_event_exclude_profile.go
+++ b/uptycs/resource_event_exclude_profile.go
@@ -1,0 +1,246 @@
+package uptycs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/uptycslabs/uptycs-client-go/uptycs"
+)
+
+type resourceEventExcludeProfileType struct{}
+
+// Resource schema
+func (r resourceEventExcludeProfileType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"id": {
+				Type:     types.StringType,
+				Computed: true,
+			},
+			"name": {
+				Type:     types.StringType,
+				Optional: true,
+			},
+			"description": {
+				Type:     types.StringType,
+				Optional: true,
+			},
+			"priority": {
+				Type:     types.NumberType,
+				Optional: true,
+			},
+			"resource_type": {
+				Type:     types.StringType,
+				Computed: true,
+			},
+			"platform": {
+				Type:     types.StringType,
+				Optional: true,
+			},
+			"metadata": {
+				Optional: true,
+				Type:     types.StringType,
+			},
+		},
+	}, nil
+}
+
+// New resource instance
+func (r resourceEventExcludeProfileType) NewResource(_ context.Context, p tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+	return resourceEventExcludeProfile{
+		p: *(p.(*provider)),
+	}, nil
+}
+
+type resourceEventExcludeProfile struct {
+	p provider
+}
+
+// Create a new resource
+func (r resourceEventExcludeProfile) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+	if !r.p.configured {
+		resp.Diagnostics.AddError(
+			"Provider not configured",
+			"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
+		)
+		return
+	}
+
+	// Retrieve values from plan
+	var plan EventExcludeProfile
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	eventExcludeProfileResp, err := r.p.client.CreateEventExcludeProfile(uptycs.EventExcludeProfile{
+		Name:         plan.Name.Value,
+		Description:  plan.Description.Value,
+		MetadataJson: plan.Metadata.Value,
+		Priority:     plan.Priority,
+		ResourceType: plan.ResourceType.Value,
+		Platform:     plan.Platform.Value,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating",
+			"Could not create eventExcludeProfile, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	metadataJson, err := json.MarshalIndent(eventExcludeProfileResp.Metadata, "", "  ")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var result = EventExcludeProfile{
+		ID:           types.String{Value: eventExcludeProfileResp.ID},
+		Name:         types.String{Value: eventExcludeProfileResp.Name},
+		Description:  types.String{Value: eventExcludeProfileResp.Description},
+		Metadata:     types.String{Value: string([]byte(metadataJson)) + "\n"},
+		Priority:     eventExcludeProfileResp.Priority,
+		ResourceType: types.String{Value: eventExcludeProfileResp.ResourceType},
+		Platform:     types.String{Value: eventExcludeProfileResp.Platform},
+	}
+
+	diags = resp.State.Set(ctx, result)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read resource information
+func (r resourceEventExcludeProfile) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+	var eventExcludeProfileId string
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, tftypes.NewAttributePath().WithAttributeName("id"), &eventExcludeProfileId)...)
+	eventExcludeProfileResp, err := r.p.client.GetEventExcludeProfile(uptycs.EventExcludeProfile{
+		ID: eventExcludeProfileId,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading",
+			"Could not get eventExcludeProfile with ID  "+eventExcludeProfileId+": "+err.Error(),
+		)
+		return
+	}
+
+	metadataJson, err := json.MarshalIndent(eventExcludeProfileResp.Metadata, "", "  ")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var result = EventExcludeProfile{
+		ID:           types.String{Value: eventExcludeProfileResp.ID},
+		Name:         types.String{Value: eventExcludeProfileResp.Name},
+		Description:  types.String{Value: eventExcludeProfileResp.Description},
+		Metadata:     types.String{Value: string([]byte(metadataJson)) + "\n"},
+		Priority:     eventExcludeProfileResp.Priority,
+		ResourceType: types.String{Value: eventExcludeProfileResp.ResourceType},
+		Platform:     types.String{Value: eventExcludeProfileResp.Platform},
+	}
+
+	diags := resp.State.Set(ctx, result)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+}
+
+// Update resource
+func (r resourceEventExcludeProfile) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+	var state EventExcludeProfile
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	eventExcludeProfileID := state.ID.Value
+
+	// Retrieve values from plan
+	var plan EventExcludeProfile
+	diags = req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	eventExcludeProfileResp, err := r.p.client.UpdateEventExcludeProfile(uptycs.EventExcludeProfile{
+		ID:           eventExcludeProfileID,
+		Name:         plan.Name.Value,
+		Description:  plan.Description.Value,
+		MetadataJson: plan.Metadata.Value,
+		Priority:     plan.Priority,
+		ResourceType: plan.ResourceType.Value,
+		Platform:     plan.Platform.Value,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating eventExcludeProfile",
+			"Could not create eventExcludeProfile, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	metadataJson, err := json.MarshalIndent(eventExcludeProfileResp.Metadata, "", "  ")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var result = EventExcludeProfile{
+		ID:           types.String{Value: eventExcludeProfileResp.ID},
+		Name:         types.String{Value: eventExcludeProfileResp.Name},
+		Description:  types.String{Value: eventExcludeProfileResp.Description},
+		Metadata:     types.String{Value: string([]byte(metadataJson)) + "\n"},
+		Priority:     eventExcludeProfileResp.Priority,
+		ResourceType: types.String{Value: eventExcludeProfileResp.ResourceType},
+		Platform:     types.String{Value: eventExcludeProfileResp.Platform},
+	}
+
+	diags = resp.State.Set(ctx, result)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete resource
+func (r resourceEventExcludeProfile) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+	var state EventExcludeProfile
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	eventExcludeProfileID := state.ID.Value
+
+	_, err := r.p.client.DeleteEventExcludeProfile(uptycs.EventExcludeProfile{
+		ID: eventExcludeProfileID,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting",
+			"Could not delete eventExcludeProfile with ID  "+eventExcludeProfileID+": "+err.Error(),
+		)
+		return
+	}
+
+	// Remove resource from state
+	resp.State.RemoveResource(ctx)
+}
+
+// Import resource
+func (r resourceEventExcludeProfile) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
+}

--- a/uptycs/resource_event_rule.go
+++ b/uptycs/resource_event_rule.go
@@ -235,7 +235,6 @@ func (r resourceEventRule) Read(ctx context.Context, req tfsdk.ReadResourceReque
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error reading order",
 			"Could not get eventRule with ID  "+eventRuleId+": "+err.Error(),
 		)
 		return
@@ -405,7 +404,6 @@ func (r resourceEventRule) Delete(ctx context.Context, req tfsdk.DeleteResourceR
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error deleting order",
 			"Could not delete eventRule with ID  "+eventRuleID+": "+err.Error(),
 		)
 		return

--- a/uptycs/resource_event_rule.go
+++ b/uptycs/resource_event_rule.go
@@ -175,7 +175,7 @@ func (r resourceEventRule) Create(ctx context.Context, req tfsdk.CreateResourceR
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error creating eventRule",
+			"Error creating",
 			"Could not create eventRule, unexpected error: "+err.Error(),
 		)
 		return
@@ -235,6 +235,7 @@ func (r resourceEventRule) Read(ctx context.Context, req tfsdk.ReadResourceReque
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
+			"Error reading",
 			"Could not get eventRule with ID  "+eventRuleId+": "+err.Error(),
 		)
 		return
@@ -336,7 +337,7 @@ func (r resourceEventRule) Update(ctx context.Context, req tfsdk.UpdateResourceR
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error creating eventRule",
+			"Error creating",
 			"Could not create eventRule, unexpected error: "+err.Error(),
 		)
 		return
@@ -404,6 +405,7 @@ func (r resourceEventRule) Delete(ctx context.Context, req tfsdk.DeleteResourceR
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
+			"Error deleting",
 			"Could not delete eventRule with ID  "+eventRuleID+": "+err.Error(),
 		)
 		return


### PR DESCRIPTION
Add support for event exclude profiles

```
Terraform will perform the following actions:

  # uptycs_event_exclude_profile.sample will be created
  + resource "uptycs_event_exclude_profile" "sample" {
      + description   = "a test2"
      + id            = (known after apply)
      + metadata      = jsonencode(
            {
              + dns_lookup_events   = {}
              + process_events      = {
                  + path = [
                      + "^/Library/Developer/Xcode$",
                    ]
                }
              + process_file_events = {
                  + executable = [
                      + "^.*osqueryd\\.exe$|^.*collectguestlogs\\.exe$|^.*MsMpEng\\.exe$",
                    ]
                  + path       = [
                      + "^/Library/Developer/Xcode$",
                      + "^/Library/Application Support/JAMF$",
                    ]
                }
              + registry_events     = {}
              + socket_events       = {}
              + user_events         = {}
            }
        )
      + name          = "marc test"
      + platform      = "all"
      + priority      = 9999
      + resource_type = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
uptycs_event_exclude_profile.sample: Creating...
uptycs_event_exclude_profile.sample: Creation complete after 0s [id=ecc19d4e-b9e6-4f9a-ae71-2b2844d36fa0]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```