### PR TITLE
Bugfix: dont require platform as it can be null and defaults to empty str

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,17 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=uptycslabs
 NAME=uptycs
 BINARY=terraform-provider-${NAME}
-VERSION = 0.0.11
+VERSION = 0.0.12
 GOOS = darwin
 GOARCH = amd64
 
 default: install
 
 bump_version:
-	find _examples -type f -name '*.tf' -exec sed -i '' "s/version = \".*\"/version = \"$(VERSION)\"/g" {} +
-	sed -i '' "s/version = \".*\"/version = \"$(VERSION)\"/g" README.md
-	sed -i '' -e '1s/VERSION = .*/VERSION = $(VERSION)/;t' -e '1,/VERSION = .*/s//VERSION = $(VERSION)/' Makefile
+	find _examples -type f -name '*.tf' -exec sed -i.bak "s/version = \".*\"/version = \"$(VERSION)\"/g" {} +
+	sed -i.bak "s/version = \".*\"/version = \"$(VERSION)\"/g" README.md
+	sed -i.bak -e '1s/VERSION = .*/VERSION = $(VERSION)/;t' -e '1,/VERSION = .*/s//VERSION = $(VERSION)/' Makefile
+	find . -name '*.bak' -delete
 
 
 build:

--- a/_examples/alert_rule.tf
+++ b/_examples/alert_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/audit_configuration.tf
+++ b/_examples/audit_configuration.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/destination.tf
+++ b/_examples/destination.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/event_exclude_profiles.tf
+++ b/_examples/event_exclude_profiles.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/event_rule.tf
+++ b/_examples/event_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/file_path_group.tf
+++ b/_examples/file_path_group.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/querypack.tf
+++ b/_examples/querypack.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/registry_path.tf
+++ b/_examples/registry_path.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/role.tf
+++ b/_examples/role.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/tag.tf
+++ b/_examples/tag.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/tag_rule.tf
+++ b/_examples/tag_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/user.tf
+++ b/_examples/user.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/_examples/yara_group_rule.tf
+++ b/_examples/yara_group_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }

--- a/docs/resources/tag_rule.md
+++ b/docs/resources/tag_rule.md
@@ -19,7 +19,6 @@ description: |-
 
 - `description` (String)
 - `name` (String)
-- `platform` (String)
 - `query` (String)
 - `run_once` (Boolean)
 - `source` (String)
@@ -29,6 +28,7 @@ description: |-
 - `enabled` (Boolean)
 - `interval` (Number)
 - `osquery_version` (String)
+- `platform` (String)
 - `resource_type` (String)
 - `system` (Boolean)
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.5.0
 	github.com/hashicorp/terraform-plugin-go v0.14.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0
-	github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220919152844-ba0f0c989eff
+	github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930161310-f71c00845b64
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.5.0
 	github.com/hashicorp/terraform-plugin-go v0.14.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0
-	github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930161310-f71c00845b64
+	github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930181445-2e897c2a3630
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,10 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220919152844-ba0f0c989eff h1:XLdDEnVotJr9Pv0EZay6qCtNd66+qddAhxG2TQJrXuM=
-github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220919152844-ba0f0c989eff/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
+github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930145613-ac3107c9cdb2 h1:GPQloCu0awYHnlCNsKZVmrs0pXvNFaF/ilAu9jwd1L8=
+github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930145613-ac3107c9cdb2/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
+github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930161310-f71c00845b64 h1:wJkFGON4oGYKoisr8vaw+WB0duLlqdleDR1ABH/mjUQ=
+github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930161310-f71c00845b64/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -248,10 +248,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930145613-ac3107c9cdb2 h1:GPQloCu0awYHnlCNsKZVmrs0pXvNFaF/ilAu9jwd1L8=
-github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930145613-ac3107c9cdb2/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
-github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930161310-f71c00845b64 h1:wJkFGON4oGYKoisr8vaw+WB0duLlqdleDR1ABH/mjUQ=
-github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930161310-f71c00845b64/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
+github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930181445-2e897c2a3630 h1:sVOkWDD3dwDoWB5/BMHXrlZGRwxRLWvsoGcvLxxklzc=
+github.com/uptycslabs/uptycs-client-go v0.0.23-0.20220930181445-2e897c2a3630/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/uptycs/resource_tag_rule.go
+++ b/uptycs/resource_tag_rule.go
@@ -53,8 +53,10 @@ func (r resourceTagRuleType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 				PlanModifiers: tfsdk.AttributePlanModifiers{resource.UseStateForUnknown(), stringDefault("")},
 			},
 			"platform": {
-				Type:     types.StringType,
-				Required: true,
+				Type:          types.StringType,
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: tfsdk.AttributePlanModifiers{resource.UseStateForUnknown(), stringDefault("")},
 			},
 			"resource_type": {
 				Type:          types.StringType,


### PR DESCRIPTION
Tested with

```

resource "uptycs_tag" "new_tag" {
  key   = "marcus_test"
  flag_profile_id  = "11111111111111-111111-1111111-1111111111"
  file_path_groups       = []
  audit_configurations   = []
  event_exclude_profiles = []
  querypacks             = []
  registry_paths         = []
  yara_group_rules       = []
}


resource "uptycs_tag_rule" "new_tr" {
  name        = "marcus test"
  description = "a test tag rule"
  interval    = 3600
  source      = "global"
  run_once    = false
  query       = <<EOT
select 
'marcus_test' as tag,
upt_asset_id
from aws_ec2_instance_current
where account_id = '111111111'
and JSON_EXTRACT_scalar(tags, '$.Component') = 'Some Component'
EOT
}
```