### PR TITLE
Fix alert count/interval, changes to eventrule types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=uptycslabs
 NAME=uptycs
 BINARY=terraform-provider-${NAME}
-VERSION = 0.0.19
+VERSION = 0.0.20
 GOOS = darwin
 GOARCH = amd64
 

--- a/_examples/alert_rule.tf
+++ b/_examples/alert_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }
@@ -23,6 +23,8 @@ output "test_rule" {
 }
 
 resource "uptycs_alert_rule" "test_alert_rule" {
+  code        = "AWS_THREAT_PRIV_ESC_1_MARCUS"
+  description = "Access Key created by an IAM user for another user using CreateAccessKey policy."
   alert_tags = [
     "ATTACK",
     "AWS",
@@ -31,8 +33,6 @@ resource "uptycs_alert_rule" "test_alert_rule" {
     "Privilege Escalation",
     "T1078",
   ]
-  code        = "AWS_THREAT_PRIV_ESC_1_MARCUS"
-  description = "Access Key created by an IAM user for another user using CreateAccessKey policy."
   destinations = [
     {
       close_after_delivery = true
@@ -41,7 +41,6 @@ resource "uptycs_alert_rule" "test_alert_rule" {
       severity             = ""
     },
   ]
-  enabled         = true
   grouping        = "ATTACK"
   grouping_l2     = "Privilege Escalation"
   grouping_l3     = "T1078"

--- a/_examples/alert_rule_category.tf
+++ b/_examples/alert_rule_category.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/asset_group_rule.tf
+++ b/_examples/asset_group_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/atc_query.tf
+++ b/_examples/atc_query.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/audit_configuration.tf
+++ b/_examples/audit_configuration.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/compliance_profile.tf
+++ b/_examples/compliance_profile.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/custom_profile.tf
+++ b/_examples/custom_profile.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/destination.tf
+++ b/_examples/destination.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/event_exclude_profiles.tf
+++ b/_examples/event_exclude_profiles.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/event_rule.tf
+++ b/_examples/event_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }
@@ -45,7 +45,7 @@ resource "uptycs_event_rule" "Access_Key_Created" {
     "field": "event_time",
     "lookupSource": {
       "type": "VALUE",
-      "table_name": {}
+      "table_name": null
     }
   }
 ]
@@ -91,48 +91,4 @@ EOT
 }
 EOT
   }
-}
-
-resource "uptycs_event_rule" "a_different_rule" {
-  name        = "Access Key Created"
-  description = "Access Key created by an IAM user for another user using CreateAccessKey policy."
-  enabled     = false
-  grouping    = "ATTACK"
-  grouping_l2 = "Privilege Escalation"
-  grouping_l3 = "T1078"
-  code        = "AWS_THREAT_PRIV_ESC_1"
-  type        = "builder"
-  rule        = "builder"
-  event_tags = [
-    "ATTACK",
-    "AWS",
-    "Cloud",
-    "IAM",
-    "Privilege Escalation",
-    "T1078",
-    "THREAT",
-    "elastalert"
-  ]
-  builder_config = <<EOT
-{
-  "tableName": "process_open_sockets",
-  "added": true,
-  "matchesFilter": true,
-  "filters": {
-    "and": [
-      {
-        "not": true,
-        "name": "remote_address",
-        "value": "^172.(1[6-9]|2[0-9]|3[01])|^10.|^192.168.",
-        "operator": "MATCHES_REGEX"
-      }
-    ]
-  },
-  "severity": "low",
-  "key": "Test",
-  "valueField": "pid",
-  "autoAlertConfig": {},
-  "addedStr": "true"
-}
-EOT
 }

--- a/_examples/exception.tf
+++ b/_examples/exception.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/file_path_group.tf
+++ b/_examples/file_path_group.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/flag_profile.tf
+++ b/_examples/flag_profile.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/querypack.tf
+++ b/_examples/querypack.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/registry_path.tf
+++ b/_examples/registry_path.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/role.tf
+++ b/_examples/role.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/tag.tf
+++ b/_examples/tag.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/tag_rule.tf
+++ b/_examples/tag_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/user.tf
+++ b/_examples/user.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/_examples/yara_group_rule.tf
+++ b/_examples/yara_group_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.19"
+      version = "0.0.20"
     }
   }
 }

--- a/docs/resources/alert_rule.md
+++ b/docs/resources/alert_rule.md
@@ -17,16 +17,16 @@ description: |-
 
 ### Required
 
-- `alert_tags` (List of String)
 - `code` (String)
 - `description` (String)
 - `destinations` (Attributes List) (see [below for nested schema](#nestedatt--destinations))
-- `enabled` (Boolean)
 - `grouping` (String)
 - `grouping_l2` (String)
 - `grouping_l3` (String)
 - `is_internal` (Boolean)
 - `name` (String)
+- `notify_count` (Number)
+- `notify_interval` (Number)
 - `rule` (String)
 - `rule_exceptions` (List of String)
 - `throttled` (Boolean)
@@ -34,12 +34,12 @@ description: |-
 
 ### Optional
 
-- `notify_count` (Number)
-- `notify_interval` (Number)
+- `alert_tags` (List of String)
 - `sql_config` (Attributes) (see [below for nested schema](#nestedatt--sql_config))
 
 ### Read-Only
 
+- `enabled` (Boolean)
 - `id` (String) The ID of this resource.
 
 <a id="nestedatt--destinations"></a>

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0
-	github.com/uptycslabs/uptycs-client-go v0.0.26-0.20221201220835-f677f50b56b5
+	github.com/uptycslabs/uptycs-client-go v0.0.26-0.20230119213017-835dcffe76ab
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0
-	github.com/uptycslabs/uptycs-client-go v0.0.26-0.20230119213017-835dcffe76ab
+	github.com/uptycslabs/uptycs-client-go v0.0.26
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -249,12 +249,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/uptycslabs/uptycs-client-go v0.0.26-0.20221201190850-e79af9cbd1b6 h1:DQ9MBYeicfh58I1HQANzQ/egGFRS9mriIISvnT6epsc=
-github.com/uptycslabs/uptycs-client-go v0.0.26-0.20221201190850-e79af9cbd1b6/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
-github.com/uptycslabs/uptycs-client-go v0.0.26-0.20221201212412-ce7d9317221b h1:5RwQB/QO/J0XRULLN4ahPyU6nccAqztjg8U18P/1xT8=
-github.com/uptycslabs/uptycs-client-go v0.0.26-0.20221201212412-ce7d9317221b/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
-github.com/uptycslabs/uptycs-client-go v0.0.26-0.20221201220835-f677f50b56b5 h1:m0RVEknb0H2B09AoEnsh5wxv9AYdEIzKrNYFsnV1H0M=
-github.com/uptycslabs/uptycs-client-go v0.0.26-0.20221201220835-f677f50b56b5/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
+github.com/uptycslabs/uptycs-client-go v0.0.26-0.20230119213017-835dcffe76ab h1:8LmlH2ms2fOy+L5H5TfU0eKDy+ncslaM0ul5njxghKw=
+github.com/uptycslabs/uptycs-client-go v0.0.26-0.20230119213017-835dcffe76ab/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/uptycslabs/uptycs-client-go v0.0.26-0.20230119213017-835dcffe76ab h1:8LmlH2ms2fOy+L5H5TfU0eKDy+ncslaM0ul5njxghKw=
 github.com/uptycslabs/uptycs-client-go v0.0.26-0.20230119213017-835dcffe76ab/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
+github.com/uptycslabs/uptycs-client-go v0.0.26 h1:hCXR0gefpG1p4R5O8ODkMHaxCH7zp/TQewJSOayF6VQ=
+github.com/uptycslabs/uptycs-client-go v0.0.26/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/uptycs/data_source_alert_rule.go
+++ b/uptycs/data_source_alert_rule.go
@@ -92,11 +92,11 @@ func (d *alertRuleDataSource) GetSchema(_ context.Context) (tfsdk.Schema, diag.D
 				Optional: true,
 			},
 			"notify_interval": {
-				Type:     types.NumberType,
+				Type:     types.Int64Type,
 				Optional: true,
 			},
 			"notify_count": {
-				Type:     types.NumberType,
+				Type:     types.Int64Type,
 				Optional: true,
 			},
 			"rule_exceptions": {
@@ -170,16 +170,18 @@ func (d *alertRuleDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 
 	var result = AlertRule{
-		ID:          types.String{Value: alertRuleResp.ID},
-		Name:        types.String{Value: alertRuleResp.Name},
-		Description: types.String{Value: alertRuleResp.Description},
-		Code:        types.String{Value: alertRuleResp.Code},
-		Type:        types.String{Value: alertRuleResp.Type},
-		Rule:        types.String{Value: alertRuleResp.Rule},
-		Grouping:    types.String{Value: alertRuleResp.Grouping},
-		Enabled:     types.Bool{Value: alertRuleResp.Enabled},
-		Throttled:   types.Bool{Value: alertRuleResp.Throttled},
-		IsInternal:  types.Bool{Value: alertRuleResp.IsInternal},
+		ID:                  types.String{Value: alertRuleResp.ID},
+		Name:                types.String{Value: alertRuleResp.Name},
+		Description:         types.String{Value: alertRuleResp.Description},
+		Code:                types.String{Value: alertRuleResp.Code},
+		Type:                types.String{Value: alertRuleResp.Type},
+		Rule:                types.String{Value: alertRuleResp.Rule},
+		Grouping:            types.String{Value: alertRuleResp.Grouping},
+		Enabled:             types.Bool{Value: alertRuleResp.Enabled},
+		Throttled:           types.Bool{Value: alertRuleResp.Throttled},
+		IsInternal:          types.Bool{Value: alertRuleResp.IsInternal},
+		AlertNotifyCount:    types.Int64{Value: int64(alertRuleResp.AlertNotifyCount)},
+		AlertNotifyInterval: types.Int64{Value: int64(alertRuleResp.AlertNotifyInterval)},
 		AlertTags: types.List{
 			ElemType: types.StringType,
 			Elems:    make([]attr.Value, 0),
@@ -190,13 +192,6 @@ func (d *alertRuleDataSource) Read(ctx context.Context, req datasource.ReadReque
 			ElemType: types.StringType,
 			Elems:    make([]attr.Value, 0),
 		},
-	}
-
-	if alertRuleResp.AlertNotifyInterval != 0 {
-		result.AlertNotifyInterval = &alertRuleResp.AlertNotifyInterval
-	}
-	if alertRuleResp.AlertNotifyCount != 0 {
-		result.AlertNotifyCount = &alertRuleResp.AlertNotifyCount
 	}
 
 	if alertRuleResp.SQLConfig != nil {

--- a/uptycs/models.go
+++ b/uptycs/models.go
@@ -18,21 +18,11 @@ type AlertRule struct {
 	AlertTags           types.List             `tfsdk:"alert_tags"`
 	GroupingL2          types.String           `tfsdk:"grouping_l2"`
 	GroupingL3          types.String           `tfsdk:"grouping_l3"`
-	AlertNotifyInterval *int                   `tfsdk:"notify_interval"`
-	AlertNotifyCount    *int                   `tfsdk:"notify_count"`
+	AlertNotifyInterval types.Int64            `tfsdk:"notify_interval"`
+	AlertNotifyCount    types.Int64            `tfsdk:"notify_count"`
 	AlertRuleExceptions types.List             `tfsdk:"rule_exceptions"`
 	Destinations        []AlertRuleDestination `tfsdk:"destinations"`
 	SQLConfig           *SQLConfig             `tfsdk:"sql_config"`
-	//ScriptConfig        *ScriptConfig          `tfsdk:"script_config"` //TODO cant find any examples
-}
-
-type ScriptConfig struct {
-	ID               types.String `tfsdk:"id"`
-	QueryPackID      types.String `tfsdk:"querypack_id"`
-	TableName        types.String `tfsdk:"table_name"`
-	EventCode        types.String `tfsdk:"event_code"`
-	EventMinSeverity types.String `tfsdk:"event_min_severity"`
-	Added            types.Bool   `tfsdk:"added"`
 }
 
 type AlertRuleDestination struct {

--- a/uptycs/resource_event_rule.go
+++ b/uptycs/resource_event_rule.go
@@ -56,9 +56,10 @@ func (r *eventRuleResource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Dia
 				Required: true,
 			},
 			"score": {
-				Type:     types.StringType,
-				Optional: true,
-				Computed: false,
+				Type:          types.StringType,
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: tfsdk.AttributePlanModifiers{resource.UseStateForUnknown(), stringDefault("")},
 			},
 			"code": {
 				Type:     types.StringType,
@@ -90,7 +91,7 @@ func (r *eventRuleResource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Dia
 				Type:          types.BoolType,
 				Optional:      true,
 				Computed:      true,
-				PlanModifiers: tfsdk.AttributePlanModifiers{resource.UseStateForUnknown(), boolDefault(true)},
+				PlanModifiers: tfsdk.AttributePlanModifiers{resource.UseStateForUnknown(), boolDefault(false)},
 			},
 			"event_tags": {
 				Type:     types.ListType{ElemType: types.StringType},


### PR DESCRIPTION
Fix alertNotifyCount/alertNotifyInterval using Int64type. 
Only allow creating sql alert rules. Remove ScriptConfig. 
Make alert_tags a readonly since theyre managed on eventrules