### PR TITLE
Add support and logic for bundling in alert rules to eventrules of type builder

### DIFF
--- a/_examples/event_rule.tf
+++ b/_examples/event_rule.tf
@@ -23,7 +23,20 @@ resource "uptycs_event_rule" "Access_Key_Created" {
   grouping_l3 = "T1078"
   code        = "AWS_THREAT_PRIV_ESC_1"
   type        = "builder"
-  rule        = "builder"
+  alert_rule = {
+    destinations = [
+      {
+        severity             = "medium"
+        destination_id       = data.uptycs_destination.foo.id
+        notify_every_alert   = true
+        close_after_delivery = true
+      },
+    ]
+    rule_exceptions = [
+      "ce67f12a-91d1-4a79-b0ee-a60501c5990b",
+    ]
+  }
+  rule = "builder"
   event_tags = [
     "ATTACK",
     "AWS",

--- a/docs/resources/event_rule.md
+++ b/docs/resources/event_rule.md
@@ -17,8 +17,6 @@ description: |-
 
 ### Required
 
-- `alert_rule` (Attributes) (see [below for nested schema](#nestedatt--alert_rule))
-- `builder_config` (Attributes) (see [below for nested schema](#nestedatt--builder_config))
 - `code` (String)
 - `description` (String)
 - `event_tags` (List of String)
@@ -29,10 +27,13 @@ description: |-
 
 ### Optional
 
+- `alert_rule` (Attributes) (see [below for nested schema](#nestedatt--alert_rule))
+- `builder_config` (Attributes) (see [below for nested schema](#nestedatt--builder_config))
 - `enabled` (Boolean)
 - `grouping_l2` (String)
 - `grouping_l3` (String)
 - `score` (String)
+- `sql_config` (Attributes) (see [below for nested schema](#nestedatt--sql_config))
 
 ### Read-Only
 
@@ -90,5 +91,14 @@ Required:
 Optional:
 
 - `metadata_sources` (String)
+
+
+
+<a id="nestedatt--sql_config"></a>
+### Nested Schema for `sql_config`
+
+Optional:
+
+- `interval_seconds` (Number)
 
 

--- a/docs/resources/event_rule.md
+++ b/docs/resources/event_rule.md
@@ -17,6 +17,7 @@ description: |-
 
 ### Required
 
+- `alert_rule` (Attributes) (see [below for nested schema](#nestedatt--alert_rule))
 - `builder_config` (Attributes) (see [below for nested schema](#nestedatt--builder_config))
 - `code` (String)
 - `description` (String)
@@ -36,6 +37,30 @@ description: |-
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedatt--alert_rule"></a>
+### Nested Schema for `alert_rule`
+
+Required:
+
+- `destinations` (Attributes List) (see [below for nested schema](#nestedatt--alert_rule--destinations))
+- `rule_exceptions` (List of String)
+
+Read-Only:
+
+- `enabled` (Boolean)
+
+<a id="nestedatt--alert_rule--destinations"></a>
+### Nested Schema for `alert_rule.destinations`
+
+Optional:
+
+- `close_after_delivery` (Boolean)
+- `destination_id` (String)
+- `notify_every_alert` (Boolean)
+- `severity` (String)
+
+
 
 <a id="nestedatt--builder_config"></a>
 ### Nested Schema for `builder_config`

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	github.com/myoung34/terraform-plugin-framework-utils v0.0.0-20230201184903-6cd82880569f
-	github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230201190639-2875d2113c0c
+	github.com/myoung34/terraform-plugin-framework-utils v0.0.0-20230201202102-41c2c21deae7
+	github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230201224627-7038f4636743
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/myoung34/terraform-plugin-framework-utils v0.0.0-20230201202102-41c2c21deae7
-	github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230201224627-7038f4636743
+	github.com/uptycslabs/uptycs-client-go v0.0.27
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230202080424-6ae75db6d902 h1:fU/YZVnkR9bF7XkGzAx+3rRhM4MQDV4OuZy0Zli2PWA=
-github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230202080424-6ae75db6d902/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
 github.com/uptycslabs/uptycs-client-go v0.0.27 h1:ufrLGKBmF3xGqQZV+FCVMyPuHzf5XO/X6SMa/Mhrp80=
 github.com/uptycslabs/uptycs-client-go v0.0.27/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,10 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230201224627-7038f4636743 h1:KbnZVhvZ4X7cyvIofK3EXkWsrEy9RvQMcz+SQkpuZK4=
-github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230201224627-7038f4636743/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
+github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230202080424-6ae75db6d902 h1:fU/YZVnkR9bF7XkGzAx+3rRhM4MQDV4OuZy0Zli2PWA=
+github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230202080424-6ae75db6d902/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
+github.com/uptycslabs/uptycs-client-go v0.0.27 h1:ufrLGKBmF3xGqQZV+FCVMyPuHzf5XO/X6SMa/Mhrp80=
+github.com/uptycslabs/uptycs-client-go v0.0.27/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/myoung34/terraform-plugin-framework-utils v0.0.0-20230201184903-6cd82880569f h1:HhiEQhhr1W4qpRXt9YD2/bXVddc8KTsHBFEoMRnlN4c=
-github.com/myoung34/terraform-plugin-framework-utils v0.0.0-20230201184903-6cd82880569f/go.mod h1:3Clx6Vx3+M+vDvD8KrgPAfit1iHePqWMs3+0P1rumcw=
+github.com/myoung34/terraform-plugin-framework-utils v0.0.0-20230201202102-41c2c21deae7 h1:gjY6N2q4/ygjPvyipOzNiyNJTBWXM/1oSnkcP9hrx5g=
+github.com/myoung34/terraform-plugin-framework-utils v0.0.0-20230201202102-41c2c21deae7/go.mod h1:3Clx6Vx3+M+vDvD8KrgPAfit1iHePqWMs3+0P1rumcw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -239,10 +239,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230130193611-8bb1ee615566 h1:HGMXV/2HisJa9HZ5OGwagRCI0QuDoy+mCOq4D7rupTQ=
-github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230130193611-8bb1ee615566/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
-github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230201190639-2875d2113c0c h1:7Bdnh2Y29QShF0ogPCEu2DOzrsRXue2049acksCPx7M=
-github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230201190639-2875d2113c0c/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
+github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230201224627-7038f4636743 h1:KbnZVhvZ4X7cyvIofK3EXkWsrEy9RvQMcz+SQkpuZK4=
+github.com/uptycslabs/uptycs-client-go v0.0.27-0.20230201224627-7038f4636743/go.mod h1:y4h23mQeoKTt0mpyvEMoEStW/azCQ/CSlMtLqqUlC8M=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/uptycs/data_source_alert_rule.go
+++ b/uptycs/data_source_alert_rule.go
@@ -119,7 +119,6 @@ func (d *alertRuleDataSource) Read(ctx context.Context, req datasource.ReadReque
 		AlertNotifyCount:    types.Int64Value(int64(alertRuleResp.AlertNotifyCount)),
 		AlertNotifyInterval: types.Int64Value(int64(alertRuleResp.AlertNotifyInterval)),
 		AlertTags:           makeListStringAttribute(alertRuleResp.AlertTags),
-
 		GroupingL2:          types.StringValue(alertRuleResp.GroupingL2),
 		GroupingL3:          types.StringValue(alertRuleResp.GroupingL3),
 		AlertRuleExceptions: makeListStringAttributeFn(alertRuleResp.AlertRuleExceptions, func(v uptycs.RuleException) (string, bool) { return v.ExceptionID, true }),

--- a/uptycs/data_source_event_rule.go
+++ b/uptycs/data_source_event_rule.go
@@ -135,7 +135,7 @@ func (d *eventRuleDataSource) Read(ctx context.Context, req datasource.ReadReque
 		GroupingL3:  types.StringValue(eventRuleResp.GroupingL3),
 		Score:       types.StringValue(eventRuleResp.Score),
 		EventTags:   makeListStringAttribute(eventRuleResp.EventTags),
-		BuilderConfig: BuilderConfig{
+		BuilderConfig: &BuilderConfig{
 			Filters:       types.StringValue(string(filtersJSON) + "\n"),
 			TableName:     types.StringValue(eventRuleResp.BuilderConfig.TableName),
 			Added:         types.BoolValue(eventRuleResp.BuilderConfig.Added),

--- a/uptycs/models.go
+++ b/uptycs/models.go
@@ -4,6 +4,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+type AlertRuleLite struct {
+	Enabled             types.Bool             `tfsdk:"enabled"`
+	AlertRuleExceptions types.List             `tfsdk:"rule_exceptions"`
+	Destinations        []AlertRuleDestination `tfsdk:"destinations"`
+}
+
 type AlertRule struct {
 	ID                  types.String           `tfsdk:"id"`
 	Name                types.String           `tfsdk:"name"`
@@ -49,19 +55,20 @@ type Exception struct {
 }
 
 type EventRule struct {
-	ID            types.String  `tfsdk:"id"`
-	Name          types.String  `tfsdk:"name"`
-	Description   types.String  `tfsdk:"description"`
-	Code          types.String  `tfsdk:"code"`
-	Type          types.String  `tfsdk:"type"`
-	Rule          types.String  `tfsdk:"rule"`
-	Grouping      types.String  `tfsdk:"grouping"`
-	GroupingL2    types.String  `tfsdk:"grouping_l2"`
-	GroupingL3    types.String  `tfsdk:"grouping_l3"`
-	Score         types.String  `tfsdk:"score"`
-	Enabled       types.Bool    `tfsdk:"enabled"`
-	EventTags     types.List    `tfsdk:"event_tags"`
-	BuilderConfig BuilderConfig `tfsdk:"builder_config"`
+	ID            types.String   `tfsdk:"id"`
+	Name          types.String   `tfsdk:"name"`
+	Description   types.String   `tfsdk:"description"`
+	Code          types.String   `tfsdk:"code"`
+	Type          types.String   `tfsdk:"type"`
+	Rule          types.String   `tfsdk:"rule"`
+	Grouping      types.String   `tfsdk:"grouping"`
+	GroupingL2    types.String   `tfsdk:"grouping_l2"`
+	GroupingL3    types.String   `tfsdk:"grouping_l3"`
+	Score         types.String   `tfsdk:"score"`
+	Enabled       types.Bool     `tfsdk:"enabled"`
+	EventTags     types.List     `tfsdk:"event_tags"`
+	BuilderConfig BuilderConfig  `tfsdk:"builder_config"`
+	AlertRule     *AlertRuleLite `tfsdk:"alert_rule"`
 }
 
 type BuilderConfig struct {

--- a/uptycs/models.go
+++ b/uptycs/models.go
@@ -67,8 +67,9 @@ type EventRule struct {
 	Score         types.String   `tfsdk:"score"`
 	Enabled       types.Bool     `tfsdk:"enabled"`
 	EventTags     types.List     `tfsdk:"event_tags"`
-	BuilderConfig BuilderConfig  `tfsdk:"builder_config"`
+	BuilderConfig *BuilderConfig `tfsdk:"builder_config"`
 	AlertRule     *AlertRuleLite `tfsdk:"alert_rule"`
+	SQLConfig     *SQLConfig     `tfsdk:"sql_config"`
 }
 
 type BuilderConfig struct {

--- a/uptycs/resource_event_rule.go
+++ b/uptycs/resource_event_rule.go
@@ -400,8 +400,13 @@ func (r *eventRuleResource) Create(ctx context.Context, req resource.CreateReque
 
 			alertRuleResp, err := r.client.GetAlertRule(uptycs.AlertRule{ID: eventRuleResp.ID})
 			if err == nil {
-				result.AlertRule = &AlertRuleLite{
-					Enabled: types.BoolValue(alertRuleResp.Enabled),
+				if plan.AlertRule == nil {
+					resp.Diagnostics.AddError(
+						"Error creating",
+						"Could not manage attached alertRule. alert_rule = { destinations = [], rule_exceptions = [] } is required at a minimum for event rules with type 'builder'",
+					)
+					_, _ = r.client.DeleteEventRule(uptycs.EventRule{ID: eventRuleResp.ID})
+					return
 				}
 
 				var ruleExceptions []string

--- a/uptycs/resource_event_rule.go
+++ b/uptycs/resource_event_rule.go
@@ -445,6 +445,21 @@ func (r *eventRuleResource) Create(ctx context.Context, req resource.CreateReque
 				result.AlertRule.Destinations = plan.AlertRule.Destinations
 			}
 		}
+	} else {
+		if plan.BuilderConfig != nil {
+			resp.Diagnostics.AddError(
+				"Error creating",
+				"builder_config should not be set for event_rules with type 'sql'",
+			)
+			return
+		}
+		if plan.AlertRule != nil {
+			resp.Diagnostics.AddError(
+				"Error creating",
+				"alert_rule should not be set for event_rules with type 'sql'",
+			)
+			return
+		}
 	}
 
 	diags = resp.State.Set(ctx, result)
@@ -678,6 +693,21 @@ func (r *eventRuleResource) Update(ctx context.Context, req resource.UpdateReque
 			}
 		}
 
+	} else {
+		if plan.BuilderConfig != nil {
+			resp.Diagnostics.AddError(
+				"Error updating",
+				"builder_config should not be set for event_rules with type 'sql'",
+			)
+			return
+		}
+		if plan.AlertRule != nil {
+			resp.Diagnostics.AddError(
+				"Error updating",
+				"alert_rule should not be set for event_rules with type 'sql'",
+			)
+			return
+		}
 	}
 
 	diags = resp.State.Set(ctx, result)


### PR DESCRIPTION
for eventrules with type "builder" and " builder_config.auto_alert_config.raise_alert" as `true` we can now just bundle them into state together

This means we dont have to watch them separately when the API fort alertRules in this scenario is basically hands off

We can manage:
* destinations[]
* rule exceptions[]

We have read-only attributes (helpful for detecting drift) for:
* enabled