### PR TITLE
Bugfix: allow setting of alert_rule.enabled on event_rule subtype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=uptycslabs
 NAME=uptycs
 BINARY=terraform-provider-${NAME}
-VERSION = 0.0.24
+VERSION = 0.0.25
 GOOS = darwin
 GOARCH = amd64
 

--- a/_examples/alert_rule.tf
+++ b/_examples/alert_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/alert_rule_category.tf
+++ b/_examples/alert_rule_category.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/asset_group_rule.tf
+++ b/_examples/asset_group_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/atc_query.tf
+++ b/_examples/atc_query.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/audit_configuration.tf
+++ b/_examples/audit_configuration.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/compliance_profile.tf
+++ b/_examples/compliance_profile.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/custom_profile.tf
+++ b/_examples/custom_profile.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/destination.tf
+++ b/_examples/destination.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/event_exclude_profiles.tf
+++ b/_examples/event_exclude_profiles.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/event_rule.tf
+++ b/_examples/event_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/exception.tf
+++ b/_examples/exception.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/file_path_group.tf
+++ b/_examples/file_path_group.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/flag_profile.tf
+++ b/_examples/flag_profile.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/lookup_table.tf
+++ b/_examples/lookup_table.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/querypack.tf
+++ b/_examples/querypack.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/registry_path.tf
+++ b/_examples/registry_path.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/role.tf
+++ b/_examples/role.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/tag.tf
+++ b/_examples/tag.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/tag_rule.tf
+++ b/_examples/tag_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/user.tf
+++ b/_examples/user.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/_examples/yara_group_rule.tf
+++ b/_examples/yara_group_rule.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptycs = {
       source  = "uptycslabs/uptycs"
-      version = "0.0.24"
+      version = "0.0.25"
     }
   }
 }

--- a/docs/resources/event_rule.md
+++ b/docs/resources/event_rule.md
@@ -47,7 +47,7 @@ Required:
 - `destinations` (Attributes List) (see [below for nested schema](#nestedatt--alert_rule--destinations))
 - `rule_exceptions` (List of String)
 
-Read-Only:
+Optional:
 
 - `enabled` (Boolean)
 

--- a/uptycs/resource_event_rule.go
+++ b/uptycs/resource_event_rule.go
@@ -119,9 +119,10 @@ func (r *eventRuleResource) Schema(_ context.Context, req resource.SchemaRequest
 				Optional: true,
 				Attributes: map[string]schema.Attribute{
 					"enabled": schema.BoolAttribute{
-						Computed: true,
+						Optional: true,
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.UseStateForUnknown(),
+							modifiers.DefaultBool(false),
 						},
 					},
 					"rule_exceptions": schema.ListAttribute{


### PR DESCRIPTION

Trying to set enabled in alert_rule before:

```
╷
│ Error: Invalid Configuration for Read-Only Attribute
│ 
│   with uptycs_event_rule.foo,
│   on foo.tf line 4, in resource "uptycs_event_rule" "foo":
│    4:   enabled     = true
│ 
│ Cannot set value for this attribute as the provider has marked it as read-only. Remove the configuration line setting the value.
```